### PR TITLE
Read charCount from props

### DIFF
--- a/lib/src/TextArea.js
+++ b/lib/src/TextArea.js
@@ -19,8 +19,7 @@ export default class TextArea extends Component {
   };
 
   renderCharCount() {
-    const { maxCharLimit, charCountColor, exceedCharCountColor } = this.props;
-    const { charCount } = this.state;
+    const { maxCharLimit, charCountColor, exceedCharCountColor, charCount } = this.props;
 
     if (!maxCharLimit) return null;
 


### PR DESCRIPTION
When you try to set a default value for the TextArea the counter starts by 0 instead of reading the property **_charCount_**:

```
<TextArea
  maxCharLimit={400}
  value={this.state.description}
  placeholderTextColor="black"
  exceedCharCountColor="#990606"
  charCount={this.state.description.length}
  onChangeText={(text) => this.setState({description: text})}
/>
```

This pull request fixes this by reading charCount from props.
